### PR TITLE
feat: Re-export rive_rs

### DIFF
--- a/examples/rive-events.rs
+++ b/examples/rive-events.rs
@@ -1,8 +1,10 @@
 //! An example showcasing how to receive events from a Rive state machine.
 
 use bevy::{prelude::*, render::render_resource::Extent3d, window};
-use rive_bevy::{GenericEvent, RivePlugin, SceneTarget, SpriteEntity, StateMachine};
-use rive_rs::state_machine::Property;
+use rive_bevy::{
+    rive_rs::state_machine::Property, GenericEvent, RivePlugin, SceneTarget, SpriteEntity,
+    StateMachine,
+};
 
 fn main() {
     App::new()

--- a/examples/rive-input.rs
+++ b/examples/rive-input.rs
@@ -4,9 +4,9 @@
 use bevy::{prelude::*, render::render_resource::Extent3d, window};
 use rive_bevy::{
     events::{self, InputValue},
+    rive_rs::components::TextValueRun,
     RivePlugin, RiveStateMachine, SceneTarget, SpriteEntity, StateMachine,
 };
-use rive_rs::components::TextValueRun;
 
 const BACKGROUND_COLOR: Color = Color::rgb(0.0, 0.0, 0.0);
 

--- a/examples/shmup.rs
+++ b/examples/shmup.rs
@@ -13,9 +13,9 @@ use bevy::{
 use rand::prelude::*;
 
 use rive_bevy::{
-    events, Riv, RivePlugin, RiveStateMachine, SceneTarget, SpriteEntity, StateMachine,
+    events, rive_rs::scene::Scene, Riv, RivePlugin, RiveStateMachine, SceneTarget, SpriteEntity,
+    StateMachine,
 };
-use rive_rs::scene::Scene;
 
 // const BACKGROUND_COLOR: Color = Color::rgb(0.0, 0.0, 0.0);
 const BACKGROUND_COLOR: Color = Color::rgb(0.023, 0.0, 0.102);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@ mod node;
 mod plugin;
 mod pointer_events;
 
+// Re-export rive-rs
+pub use rive_rs;
+
 pub use crate::{
     assets::Riv,
     components::{
@@ -13,5 +16,5 @@ pub use crate::{
     },
     events::GenericEvent,
     plugin::RivePlugin,
+    rive_rs::Handle,
 };
-pub use rive_rs::Handle;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use bevy::{
     core_pipeline::{core_2d, core_3d},
     ecs::query::BatchingStrategy,
@@ -9,7 +11,6 @@ use bevy::{
     utils::HashMap,
 };
 use rive_rs::Instantiate;
-use std::sync::Arc;
 
 use crate::{
     assets::{self, Riv, RivLoader},

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use bevy::{
     core_pipeline::{core_2d, core_3d},
     ecs::query::BatchingStrategy,
@@ -11,6 +9,7 @@ use bevy::{
     utils::HashMap,
 };
 use rive_rs::Instantiate;
+use std::sync::Arc;
 
 use crate::{
     assets::{self, Riv, RivLoader},


### PR DESCRIPTION
# Problem

Those who pull in rive-bevy shouldn't need to pull in rive-rs. By re-exporting the version of rive-rs, users following the example won't face issues and, for maintainability, the end-user doesn't need to ensure versions match.

# Solution

- Re-export rive_rs
- Examples now use `rive_bevy::rive_rs:_` instead of `rive_rs::_` imports