### PR TITLE
fix: clippy lints

### DIFF
--- a/examples/shmup.rs
+++ b/examples/shmup.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+
 //! Shoot em up! A simple demo game using Rive and Bevy.
 //! Community animation files:
 //! - https://rive.app/community/4895-9902-bug-enemy/

--- a/examples/shmup.rs
+++ b/examples/shmup.rs
@@ -361,6 +361,7 @@ fn player_movement_system(
 }
 
 // Randomize the enemy animation start time.
+#[allow(clippy::type_complexity)]
 fn instantiate_enemies_system(
     mut commands: Commands,
     mut query: Query<(Entity, &mut RiveStateMachine), (Without<StartingTime>, Without<Player>)>,

--- a/examples/shmup.rs
+++ b/examples/shmup.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 //! Shoot em up! A simple demo game using Rive and Bevy.
 //! Community animation files:
 //! - https://rive.app/community/4895-9902-bug-enemy/
@@ -361,7 +362,6 @@ fn player_movement_system(
 }
 
 // Randomize the enemy animation start time.
-#[allow(clippy::type_complexity)]
 fn instantiate_enemies_system(
     mut commands: Commands,
     mut query: Query<(Entity, &mut RiveStateMachine), (Without<StartingTime>, Without<Player>)>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::type_complexity)]
+
 mod assets;
 mod components;
 pub mod events;


### PR DESCRIPTION
Clippy has a lint for type complexity that is always in competition with Bevy system parameters.
<img width="1301" alt="image" src="https://github.com/rive-app/rive-bevy/assets/48108917/062b38ac-8d1f-4165-902b-a577384b3ea3">

This PR allows type complexity in the library and relevant examples.