### PR TITLE
Add information about `cargo update` to fetch submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Run one of the example projects:
 ```bash
 git clone https://github.com/rive-app/rive-bevy
 cd rive-bevy/
+cargo update
 cargo run --example ui-on-cube
 ```
 


### PR DESCRIPTION
The current documentation fails at build-time if followed verbatim, adding this line fixes it.